### PR TITLE
remove proxyPortRange option

### DIFF
--- a/browsermobproxy/server.py
+++ b/browsermobproxy/server.py
@@ -83,7 +83,6 @@ class Server(RemoteServer):
         self.path = path
         self.host = options.get('address', '0.0.0.0')
         self.port = options.get('port', 8080)
-        proxy_port_range = options.get('proxyPortRange', 500)
         ttl = options.get('ttl', 0)
         use_littleproxy = options.get('use-littleproxy', True)
         self.process = None
@@ -95,7 +94,6 @@ class Server(RemoteServer):
         self.command += [path,
                          '--address=%s' % self.host,
                          '--port=%s' % self.port,
-                         '--proxyPortRange=%s' % proxy_port_range,
                          '--ttl=%s' % ttl,
                          '--use-littleproxy=%s' % use_littleproxy]
 


### PR DESCRIPTION
Origin browsermob-proxy has a bug with proxyPortRange option.

```
$ browsermob-proxy --port 9090 --proxyPortRange=500
Running BrowserMob Proxy using LittleProxy implementation. To revert to the legacy implementation, run the proxy with the command-line option '--use-littleproxy false'.
Feb 27, 2017 3:38:11 PM com.google.inject.internal.MessageProcessor visit
INFO: An exception was caught and reported. Message: java.lang.IllegalArgumentException
java.lang.IllegalArgumentException
	at net.lightbody.bmp.proxy.guice.ConfigModule.configure(ConfigModule.java:83)
	at com.google.inject.spi.Elements$RecordingBinder.install(Elements.java:223)
	at com.google.inject.spi.Elements.getElements(Elements.java:101)
	at com.google.inject.internal.InjectorShell$Builder.build(InjectorShell.java:133)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:103)
	at com.google.inject.Guice.createInjector(Guice.java:95)
	at com.google.inject.Guice.createInjector(Guice.java:72)
	at com.google.inject.Guice.createInjector(Guice.java:62)
	at net.lightbody.bmp.proxy.Main.main(Main.java:47)

Exception in thread "main" com.google.inject.CreationException: Guice creation errors:

1) No implementation for java.lang.Integer annotated with @com.google.inject.name.Named(value=port) was bound.
  while locating java.lang.Integer annotated with @com.google.inject.name.Named(value=port)
    for parameter 0 at net.lightbody.bmp.proxy.guice.JettyServerProvider.<init>(JettyServerProvider.java:19)
  at net.lightbody.bmp.proxy.guice.JettyModule.configure(JettyModule.java:10)

2) No implementation for java.lang.String annotated with @com.google.inject.name.Named(value=address) was bound.
  while locating java.lang.String annotated with @com.google.inject.name.Named(value=address)
    for parameter 1 at net.lightbody.bmp.proxy.guice.JettyServerProvider.<init>(JettyServerProvider.java:19)
  at net.lightbody.bmp.proxy.guice.JettyModule.configure(JettyModule.java:10)

3) An exception was caught and reported. Message: null
  at com.google.inject.internal.InjectorShell$Builder.build(InjectorShell.java:133)

3 errors
	at com.google.inject.internal.Errors.throwCreationExceptionIfErrorsExist(Errors.java:435)
	at com.google.inject.internal.InternalInjectorCreator.initializeStatically(InternalInjectorCreator.java:154)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:106)
	at com.google.inject.Guice.createInjector(Guice.java:95)
	at com.google.inject.Guice.createInjector(Guice.java:72)
	at com.google.inject.Guice.createInjector(Guice.java:62)
	at net.lightbody.bmp.proxy.Main.main(Main.java:47)
Caused by: java.lang.IllegalArgumentException
	at net.lightbody.bmp.proxy.guice.ConfigModule.configure(ConfigModule.java:83)
	at com.google.inject.spi.Elements$RecordingBinder.install(Elements.java:223)
	at com.google.inject.spi.Elements.getElements(Elements.java:101)
	at com.google.inject.internal.InjectorShell$Builder.build(InjectorShell.java:133)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:103)
	... 4 more
```